### PR TITLE
Out of range error fixed

### DIFF
--- a/src/sorts/ShellSort.java
+++ b/src/sorts/ShellSort.java
@@ -42,7 +42,7 @@ public class ShellSort {
     {
         int incs[] = {48, 21, 7, 3, 1};
 
-        for (int k = 0; k < 16; k++)
+        for (int k = 0; k < 5; k++)
         {
             for (int h = incs[k], i = h + lo; i < hi; i++)
             {


### PR DESCRIPTION
In partShellSort array 'incs' contains only 5 elements. But for loop provides change of 'k' from 0 to 16 and inside this loop we obtain incs[k]. It fails for k > 4.