### PR TITLE
Refactor Heap Sorts to use Writes instead of Swaps

### DIFF
--- a/src/sorts/FlippedMinHeapSort.java
+++ b/src/sorts/FlippedMinHeapSort.java
@@ -40,6 +40,7 @@ final public class FlippedMinHeapSort extends Sort {
         this.isBogoSort(false);
     }
     private void siftDown(int[] array, int length, int root, int dist) {
+		int temp = array[length - root];
         while (root <= dist / 2) {
             int leaf = 2 * root;
             if (leaf < dist && Reads.compare(array[length - leaf], array[length - leaf - 1]) == 1) {
@@ -48,11 +49,13 @@ final public class FlippedMinHeapSort extends Sort {
             Highlights.markArray(1, length - root);
             Highlights.markArray(2, length - leaf);
             Delays.sleep(1);
-            if (Reads.compare(array[length - root], array[length - leaf]) == 1) {
-                Writes.swap(array, length - root, length - leaf, 0, true, false);
+            if (Reads.compare(temp, array[length - leaf]) == 1) {
+                Writes.write(array, length - root, array[length - leaf], 0, true, false);
                 root = leaf;
             } else break;
         }
+		
+		Writes.write(array, length - root, temp, 0, true, false);
     }
     @Override
     public void runSort(int[] array, int length, int bucketCount) {

--- a/src/sorts/TernaryHeapSort.java
+++ b/src/sorts/TernaryHeapSort.java
@@ -40,32 +40,33 @@ final public class TernaryHeapSort extends Sort {
     }
 
     private void maxHeapify(int[] array, int i) {
+		int temp = array[i], root = i;
+		while(this.leftBranch(root) <= this.heapSize) {
+			int leftChild   = TernaryHeapSort.leftBranch(root);
+			int rightChild  = TernaryHeapSort.rightBranch(root);
+			int middleChild = TernaryHeapSort.middleBranch(root);
+			int largest     = leftChild;
 
-        int leftChild = TernaryHeapSort.leftBranch(i);
-        int rightChild = TernaryHeapSort.rightBranch(i);
-        int middleChild = TernaryHeapSort.middleBranch(i);
-        int largest;
+			if(rightChild <= heapSize && Reads.compare(array[rightChild], array[largest]) > 0) {
+				largest = rightChild;
+			}
 
-        largest = leftChild <= heapSize && Reads.compare(array[leftChild], array[i]) > 0 ? leftChild : i;
+			if(middleChild <= heapSize && Reads.compare(array[middleChild], array[largest]) > 0) {
+				largest = middleChild;
+			}
 
-        if(rightChild <= heapSize && Reads.compare(array[rightChild], array[largest]) > 0) {
-            largest = rightChild;
-        }
-
-        if(middleChild <= heapSize && Reads.compare(array[middleChild], array[largest]) > 0) {
-            largest = middleChild;
-        }
-
-
-        if(largest != i) {
-            Writes.swap(array, i, largest, 1, true, false);
-            this.maxHeapify(array, largest);
-        }
+			if(Reads.compare(array[largest], temp) > 0) {
+				Writes.write(array, root, array[largest], 1, true, false);
+				root = largest;
+			} else break;
+		}
+		
+		Writes.write(array, root, temp, 1, true, false);
     }
     
     private void buildMaxTernaryHeap(int[] array, int length) {
-        heapSize = length - 1;
-        for(int i = length - 1  / 3; i >= 0; i--)
+        this.heapSize = length - 1;
+        for(int i = this.heapSize / 3; i >= 0; i--)
             this.maxHeapify(array, i);
     }
     
@@ -73,10 +74,10 @@ final public class TernaryHeapSort extends Sort {
     public void runSort(int[] array, int length, int bucketCount) {
         this.buildMaxTernaryHeap(array, length);
 
-        for(int i = length - 1; i >= 0; i--){
+        for(int i = length - 1; i > 0; i--){
             Writes.swap(array, 0, i, 1, true, false); //add last element on array, i.e heap root
 
-            heapSize = heapSize - 1; //shrink heap by 1
+            this.heapSize--; //shrink heap by 1
             this.maxHeapify(array, 0);
         }
     }

--- a/src/templates/HeapSorting.java
+++ b/src/templates/HeapSorting.java
@@ -23,11 +23,9 @@ public abstract class HeapSorting extends Sort {
     }
     
     private void siftDown(int[] array, int root, int dist, int start, double sleep, boolean isMax) {
-        int compareVal = 0;
+        int compareVal = isMax ? -1 : 1;
         
-        if(isMax) compareVal = -1;
-        else compareVal = 1;
-        
+		int temp = array[start + root - 1];
         while (root <= dist / 2) {
             int leaf = 2 * root;
             if (leaf < dist && Reads.compare(array[start + leaf - 1], array[start + leaf]) == compareVal) {
@@ -36,12 +34,14 @@ public abstract class HeapSorting extends Sort {
             Highlights.markArray(1, start + root - 1);
             Highlights.markArray(2, start + leaf - 1);
             Delays.sleep(sleep);
-            if (Reads.compare(array[start + root - 1], array[start + leaf - 1]) == compareVal) {
-                Writes.swap(array, start + root - 1, start + leaf - 1, 0, true, false);
+            if (Reads.compare(temp, array[start + leaf - 1]) == compareVal) {
+                Writes.write(array, start + root - 1, array[start + leaf - 1], 0, true, false);
                 root = leaf;
             }
             else break;
         }
+		
+		Writes.write(array, start + root - 1, temp, 0, true, false);
     }
 
     private void heapify(int[] arr, int low, int high, double sleep, boolean isMax) {


### PR DESCRIPTION
Similar case that separates Optimized Gnome from Insertion.
The total amount of writes can be halved by inserting the item down the heap instead of swapping.

Changed:
Max Heap
Min Heap
Flipped Min Heap
Ternary Heap

Unchanged:
Weak Heap - makes the implementation a lot less intuitive
Poplar Heap - doesn't directly improve the sort